### PR TITLE
Feat/add dynamic nav menu

### DIFF
--- a/src/app/layout/app.menu.component.ts
+++ b/src/app/layout/app.menu.component.ts
@@ -1,4 +1,4 @@
-import { Inject, inject, OnInit } from '@angular/core';
+import { Inject, OnInit } from '@angular/core';
 import { Component } from '@angular/core';
 import { MenuItem } from 'primeng/api';
 import { menuItems as adminMenuItems } from '../admin/admin.module';

--- a/src/app/layout/app.menu.component.ts
+++ b/src/app/layout/app.menu.component.ts
@@ -29,7 +29,7 @@ export class AppMenuComponent implements OnInit {
   }
 
   /* Adds MenuItems to the navigation menu */
-  addMenuItems() {
+  private addMenuItems() {
     let childItems = new Array<MenuItem>(); // Storage for child items where parent is not added yet.
     this.menuService.getMenuItems().subscribe((navs) => {
       // Add fetched menu items
@@ -108,7 +108,7 @@ export class AppMenuComponent implements OnInit {
     }
   }
 
-  addPrototypeItems() {
+  private addPrototypeItems() {
     let prototypeItems: MenuItem = {
       label: 'Prototype',
       items: [

--- a/src/app/layout/app.menu.component.ts
+++ b/src/app/layout/app.menu.component.ts
@@ -81,10 +81,18 @@ export class AppMenuComponent implements OnInit {
         }
       });
 
+      // Loop through childItems until they are all added to the menu.
+      while (childItems.length > 0) {
+        let childItem = childItems.pop() ?? {};
+        let parentItem = this.model.find((item) => item.id == childItem.fragment);
+        parentItem == null ? childItems.push(childItem) : parentItem.items?.push(childItem);
+      }
+      /*
       childItems.forEach((child) => {
         let parentItem = this.model.find((item) => item.id == child.fragment);
         parentItem == null ? this.model.push(child) : parentItem.items?.push(child);
       });
+      */
     });
   }
 

--- a/src/app/layout/app.menu.component.ts
+++ b/src/app/layout/app.menu.component.ts
@@ -87,12 +87,6 @@ export class AppMenuComponent implements OnInit {
         let parentItem = this.model.find((item) => item.id == childItem.fragment);
         parentItem == null ? childItems.push(childItem) : parentItem.items?.push(childItem);
       }
-      /*
-      childItems.forEach((child) => {
-        let parentItem = this.model.find((item) => item.id == child.fragment);
-        parentItem == null ? this.model.push(child) : parentItem.items?.push(child);
-      });
-      */
     });
   }
 

--- a/src/app/layout/app.menu.component.ts
+++ b/src/app/layout/app.menu.component.ts
@@ -14,83 +14,86 @@ export class AppMenuComponent implements OnInit {
 
   constructor(public layoutService: LayoutService, public menuService: MenuService) {}
 
-  /* Adds MenuItems to the navigation menu */
   ngOnInit() {
+    // Add prototype menu items
+    this.addPrototypeItems();
+    // Add admin menu items
+    adminMenuItems.forEach((item) => this.model.push(item));
+
+    this.fetchMenuItems();
+  }
+
+  /* Adds MenuItems to the navigation menu */
+  fetchMenuItems() {
     let childItems = new Array<MenuItem>(); // Storage for child items where parent is not added yet.
     this.menuService.getMenuItems().subscribe((navs) => {
-      // Add prototype menu items
-      this.addPrototypeItems(),
-        // Add fetched menu items
-        navs.forEach((nav) => {
-          var menuItem: MenuItem;
-          if (nav.ifc == null) {
-            if (nav.url == null) {
-              // A root/parent item
-              menuItem = {
-                id: nav.id,
-                label: nav.label,
-                icon: 'pi pi-fw pi-bars',
-                routerLink: [],
-                items: [],
-              };
-
-              this.model.push(menuItem);
-            } else {
-              // External URL
-              menuItem = {
-                label: nav.label,
-                icon: 'pi pi-fw pi-bars',
-                url: nav.url,
-              };
-
-              this.model.push(menuItem);
-            }
-          } else {
-            // Direct link to interface
+      // Add fetched menu items
+      navs.forEach((nav) => {
+        var menuItem: MenuItem;
+        if (nav.ifc == null) {
+          if (nav.url == null) {
+            // A root/parent item
             menuItem = {
               id: nav.id,
               label: nav.label,
               icon: 'pi pi-fw pi-bars',
-              routerLink: [nav.url],
+              routerLink: [],
+              items: [],
             };
 
-            // If item has a parent, add it to the parent items.
-            // Else try adding it at the end.
-            if (nav.parent != null) {
-              menuItem.fragment = nav.parent;
-              let parentItem = this.model.find((item) => item.id == nav.parent);
-              if (parentItem == null) {
-                childItems.push(menuItem);
-              } else if (parentItem.items == null) {
-                // items was still undefined
-                parentItem.items = [menuItem];
-              } else {
-                // items has been defined. Add to array
-                parentItem.items.push(menuItem);
-              }
+            this.model.push(menuItem);
+          } else {
+            // External URL
+            menuItem = {
+              label: nav.label,
+              icon: 'pi pi-fw pi-bars',
+              url: nav.url,
+            };
+
+            this.model.push(menuItem);
+          }
+        } else {
+          // Direct link to interface
+          menuItem = {
+            id: nav.id,
+            label: nav.label,
+            icon: 'pi pi-fw pi-bars',
+            routerLink: [nav.url],
+          };
+
+          // If item has a parent, add it to the parent items.
+          // Else try adding it at the end.
+          if (nav.parent != null) {
+            menuItem.fragment = nav.parent;
+            let parentItem = this.model.find((item) => item.id == nav.parent);
+            if (parentItem == null) {
+              childItems.push(menuItem);
+            } else if (parentItem.items == null) {
+              // items was still undefined
+              parentItem.items = [menuItem];
+            } else {
+              // items has been defined. Add to array
+              parentItem.items.push(menuItem);
             }
           }
-        });
+        }
+      });
 
       childItems.forEach((child) => {
         let parentItem = this.model.find((item) => item.id == child.fragment);
         parentItem == null ? this.model.push(child) : parentItem.items?.push(child);
       });
-
-      // Add admin menu items
-      adminMenuItems.forEach((item) => this.model.push(item));
     });
   }
 
   addPrototypeItems() {
-    this.model = [
-      {
-        label: 'Prototype',
-        items: [
-          { label: 'Home', icon: 'pi pi-fw pi-home', routerLink: ['/'] },
-          { label: 'Tools', icon: 'pi pi-fw pi-code', routerLink: ['/tools'] },
-        ],
-      },
-    ];
+    let prototypeItems: MenuItem = {
+      label: 'Prototype',
+      items: [
+        { label: 'Home', icon: 'pi pi-fw pi-home', routerLink: ['/'] },
+        { label: 'Tools', icon: 'pi pi-fw pi-code', routerLink: ['/tools'] },
+      ],
+    };
+    this.model.push(prototypeItems);
   }
 }

--- a/src/app/layout/app.menu.component.ts
+++ b/src/app/layout/app.menu.component.ts
@@ -4,6 +4,8 @@ import { MenuItem } from 'primeng/api';
 import { menuItems as adminMenuItems } from '../admin/admin.module';
 import { LayoutService } from './service/app.layout.service';
 import { MenuService } from './app.menu.service';
+import { INTERFACE_ROUTE_MAP } from '../project-administration/project-administration.module';
+import { INTERFACE_ROUTE_MAPPING_TOKEN } from '../config';
 
 @Component({
   selector: 'app-menu',
@@ -58,7 +60,7 @@ export class AppMenuComponent implements OnInit {
             id: nav.id,
             label: nav.label,
             icon: 'pi pi-fw pi-bars',
-            routerLink: [nav.url],
+            routerLink: [INTERFACE_ROUTE_MAP[nav.ifc]],
           };
 
           // If item has a parent, add it to the parent items.

--- a/src/app/layout/app.menu.component.ts
+++ b/src/app/layout/app.menu.component.ts
@@ -5,7 +5,6 @@ import { menuItems as adminMenuItems } from '../admin/admin.module';
 import { LayoutService } from './service/app.layout.service';
 import { MenuService } from './app.menu.service';
 import { INTERFACE_ROUTE_MAP } from '../project-administration/project-administration.module';
-import { INTERFACE_ROUTE_MAPPING_TOKEN } from '../config';
 
 @Component({
   selector: 'app-menu',

--- a/src/app/layout/app.menu.component.ts
+++ b/src/app/layout/app.menu.component.ts
@@ -31,8 +31,11 @@ export class AppMenuComponent implements OnInit {
       // Add fetched menu items
       navs.forEach((nav) => {
         let menuItem: MenuItem;
-        if (nav.ifc == null) {
-          if (nav.url == null) {
+
+        /* Create a variable to determine the type of menu item */
+        let itemType = 2 * Number(nav.ifc != null) + Number(nav.url != null);
+        switch (itemType) {
+          case 0: {
             // A root/parent item
             menuItem = {
               id: nav.id,
@@ -43,39 +46,44 @@ export class AppMenuComponent implements OnInit {
             };
 
             this.model.push(menuItem);
-          } else {
+            break;
+          }
+          case 1: {
             // External URL
             menuItem = {
               label: nav.label,
               icon: 'pi pi-fw pi-bars',
-              url: nav.url,
+              url: nav.url ?? undefined,
             };
 
             this.model.push(menuItem);
+            break;
           }
-        } else {
-          // Direct link to interface
-          menuItem = {
-            id: nav.id,
-            label: nav.label,
-            icon: 'pi pi-fw pi-bars',
-            routerLink: [INTERFACE_ROUTE_MAP[nav.ifc]],
-          };
+          default: {
+            // Direct link to interface
+            menuItem = {
+              id: nav.id,
+              label: nav.label,
+              icon: 'pi pi-fw pi-bars',
+              routerLink: [INTERFACE_ROUTE_MAP[nav.ifc ?? 'undefined']],
+            };
 
-          // If item has a parent, add it to the parent items.
-          // Else try adding it at the end.
-          if (nav.parent != null) {
-            menuItem.fragment = nav.parent;
-            let parentItem = this.model.find((item) => item.id == nav.parent);
-            if (parentItem == null) {
-              childItems.push(menuItem);
-            } else if (parentItem.items == null) {
-              // items was still undefined
-              parentItem.items = [menuItem];
-            } else {
-              // items has been defined. Add to array
-              parentItem.items.push(menuItem);
+            // If item has a parent, add it to the parent items.
+            // Else try adding it at the end.
+            if (nav.parent != null) {
+              menuItem.fragment = nav.parent;
+              let parentItem = this.model.find((item) => item.id == nav.parent);
+              if (parentItem == null) {
+                childItems.push(menuItem);
+              } else if (parentItem.items == null) {
+                // items was still undefined
+                parentItem.items = [menuItem];
+              } else {
+                // items has been defined. Add to array
+                parentItem.items.push(menuItem);
+              }
             }
+            break;
           }
         }
       });

--- a/src/app/layout/app.menu.component.ts
+++ b/src/app/layout/app.menu.component.ts
@@ -21,16 +21,16 @@ export class AppMenuComponent implements OnInit {
     // Add admin menu items
     adminMenuItems.forEach((item) => this.model.push(item));
 
-    this.fetchMenuItems();
+    this.addMenuItems();
   }
 
   /* Adds MenuItems to the navigation menu */
-  fetchMenuItems() {
+  addMenuItems() {
     let childItems = new Array<MenuItem>(); // Storage for child items where parent is not added yet.
     this.menuService.getMenuItems().subscribe((navs) => {
       // Add fetched menu items
       navs.forEach((nav) => {
-        var menuItem: MenuItem;
+        let menuItem: MenuItem;
         if (nav.ifc == null) {
           if (nav.url == null) {
             // A root/parent item

--- a/src/app/layout/app.menu.component.ts
+++ b/src/app/layout/app.menu.component.ts
@@ -2,8 +2,8 @@ import { OnInit } from '@angular/core';
 import { Component } from '@angular/core';
 import { MenuItem } from 'primeng/api';
 import { menuItems as adminMenuItems } from '../admin/admin.module';
-import { menuItems as projectMenuItems } from '../project-administration/project-administration.module';
 import { LayoutService } from './service/app.layout.service';
+import { MenuService } from './app.menu.service';
 
 @Component({
   selector: 'app-menu',
@@ -12,9 +12,77 @@ import { LayoutService } from './service/app.layout.service';
 export class AppMenuComponent implements OnInit {
   model: MenuItem[] = [];
 
-  constructor(public layoutService: LayoutService) {}
+  constructor(public layoutService: LayoutService, public menuService: MenuService) {}
 
+  /* Adds MenuItems to the navigation menu */
   ngOnInit() {
+    let childItems = new Array<MenuItem>(); // Storage for child items where parent is not added yet.
+    this.menuService.getMenuItems().subscribe((navs) => {
+      // Add prototype menu items
+      this.addPrototypeItems(),
+        // Add fetched menu items
+        navs.forEach((nav) => {
+          var menuItem: MenuItem;
+          if (nav.ifc == null) {
+            if (nav.url == null) {
+              // A root/parent item
+              menuItem = {
+                id: nav.id,
+                label: nav.label,
+                icon: 'pi pi-fw pi-bars',
+                routerLink: [],
+                items: [],
+              };
+
+              this.model.push(menuItem);
+            } else {
+              // External URL
+              menuItem = {
+                label: nav.label,
+                icon: 'pi pi-fw pi-bars',
+                url: nav.url,
+              };
+
+              this.model.push(menuItem);
+            }
+          } else {
+            // Direct link to interface
+            menuItem = {
+              id: nav.id,
+              label: nav.label,
+              icon: 'pi pi-fw pi-bars',
+              routerLink: [nav.url],
+            };
+
+            // If item has a parent, add it to the parent items.
+            // Else try adding it at the end.
+            if (nav.parent != null) {
+              menuItem.fragment = nav.parent;
+              let parentItem = this.model.find((item) => item.id == nav.parent);
+              if (parentItem == null) {
+                childItems.push(menuItem);
+              } else if (parentItem.items == null) {
+                // items was still undefined
+                parentItem.items = [menuItem];
+              } else {
+                // items has been defined. Add to array
+                parentItem.items.push(menuItem);
+              }
+            }
+          }
+        });
+
+      childItems.forEach((child) => {
+        let parentItem = this.model.find((item) => item.id == child.fragment);
+        parentItem == null ? this.model.push(child) : parentItem.items?.push(child);
+      });
+
+      // Add admin menu items
+      adminMenuItems.forEach((item) => this.model.push(item));
+    });
+  }
+
+  addPrototypeItems() {
     this.model = [
       {
         label: 'Prototype',
@@ -23,8 +91,6 @@ export class AppMenuComponent implements OnInit {
           { label: 'Tools', icon: 'pi pi-fw pi-code', routerLink: ['/tools'] },
         ],
       },
-      ...projectMenuItems,
-      ...adminMenuItems,
     ];
   }
 }

--- a/src/app/layout/app.menu.component.ts
+++ b/src/app/layout/app.menu.component.ts
@@ -70,18 +70,15 @@ export class AppMenuComponent implements OnInit {
 
             // If item has a parent, add it to the parent items.
             // Else try adding it at the end.
-            if (nav.parent != null) {
-              menuItem.fragment = nav.parent;
-              let parentItem = this.model.find((item) => item.id == nav.parent);
-              if (parentItem == null) {
-                childItems.push(menuItem);
-              } else if (parentItem.items == null) {
-                // items was still undefined
-                parentItem.items = [menuItem];
-              } else {
-                // items has been defined. Add to array
-                parentItem.items.push(menuItem);
-              }
+            if (nav.parent == null) {
+              break;
+            }
+            menuItem.fragment = nav.parent;
+            let parentItem = this.model.find((item) => item.id == nav.parent);
+            if (parentItem == null) {
+              childItems.push(menuItem);
+            } else {
+              this.addItemToParent(parentItem, menuItem);
             }
             break;
           }
@@ -95,6 +92,16 @@ export class AppMenuComponent implements OnInit {
         parentItem == null ? childItems.push(childItem) : parentItem.items?.push(childItem);
       }
     });
+  }
+
+  addItemToParent(parentItem: MenuItem, menuItem: MenuItem) {
+    if (parentItem.items == null) {
+      // items was still undefined
+      parentItem.items = [menuItem];
+    } else {
+      // items has been defined. Add to array
+      parentItem.items.push(menuItem);
+    }
   }
 
   addPrototypeItems() {

--- a/src/app/layout/app.menu.component.ts
+++ b/src/app/layout/app.menu.component.ts
@@ -1,10 +1,10 @@
-import { OnInit } from '@angular/core';
+import { Inject, inject, OnInit } from '@angular/core';
 import { Component } from '@angular/core';
 import { MenuItem } from 'primeng/api';
 import { menuItems as adminMenuItems } from '../admin/admin.module';
 import { LayoutService } from './service/app.layout.service';
 import { MenuService } from './app.menu.service';
-import { INTERFACE_ROUTE_MAP } from '../project-administration/project-administration.module';
+import { InterfaceRouteMap, INTERFACE_ROUTE_MAPPING_TOKEN } from '../config';
 
 @Component({
   selector: 'app-menu',
@@ -13,7 +13,11 @@ import { INTERFACE_ROUTE_MAP } from '../project-administration/project-administr
 export class AppMenuComponent implements OnInit {
   model: MenuItem[] = [];
 
-  constructor(public layoutService: LayoutService, public menuService: MenuService) {}
+  constructor(
+    public layoutService: LayoutService,
+    public menuService: MenuService,
+    @Inject(INTERFACE_ROUTE_MAPPING_TOKEN) private interfaceRouteMap: InterfaceRouteMap,
+  ) {}
 
   ngOnInit() {
     // Add prototype menu items
@@ -65,7 +69,7 @@ export class AppMenuComponent implements OnInit {
               id: nav.id,
               label: nav.label,
               icon: 'pi pi-fw pi-bars',
-              routerLink: [INTERFACE_ROUTE_MAP[nav.ifc ?? 'undefined']],
+              routerLink: [this.interfaceRouteMap[nav.ifc ?? 'undefined']],
             };
 
             // If item has a parent, add it to the parent items.

--- a/src/app/layout/app.menu.service.ts
+++ b/src/app/layout/app.menu.service.ts
@@ -1,11 +1,17 @@
 import { Injectable } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Subject, map, Observable } from 'rxjs';
+import { Navbar, Navs } from '../shared/interfacing/navbar.interface';
 import { MenuChangeEvent } from './api/menuchangeevent';
+import { HttpClient } from '@angular/common/http';
+import { MenuItem } from 'primeng/api/menuitem';
+import { MenuItemContent } from 'primeng/menu';
 
 @Injectable({
   providedIn: 'root',
 })
 export class MenuService {
+  constructor(private http: HttpClient) {}
+
   private menuSource = new Subject<MenuChangeEvent>();
   private resetSource = new Subject();
 
@@ -18,5 +24,12 @@ export class MenuService {
 
   reset() {
     this.resetSource.next(true);
+  }
+
+  /* Obtain navbar navs and convert them to MenuItems */
+  getMenuItems(): Observable<Array<Navs>> {
+    let navbar = this.http.get<Navbar>('app/navbar');
+    let navs: Observable<Array<Navs>> = navbar.pipe(map((x) => x.navs));
+    return navs;
   }
 }

--- a/src/app/layout/app.menu.service.ts
+++ b/src/app/layout/app.menu.service.ts
@@ -3,8 +3,6 @@ import { Subject, map, Observable } from 'rxjs';
 import { Navbar, Navs } from '../shared/interfacing/navbar.interface';
 import { MenuChangeEvent } from './api/menuchangeevent';
 import { HttpClient } from '@angular/common/http';
-import { MenuItem } from 'primeng/api/menuitem';
-import { MenuItemContent } from 'primeng/menu';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/project-administration/project-administration.module.ts
+++ b/src/app/project-administration/project-administration.module.ts
@@ -78,7 +78,7 @@ export const menuItems: MenuItem[] = [];
   },
 ];*/
 
-const INTERFACE_ROUTE_MAP: InterfaceRouteMap = {
+export const INTERFACE_ROUTE_MAP: InterfaceRouteMap = {
   Active_32_projects: '/p/active-projects',
   Edit_32_interface: '/p/edit-interface',
   Edit_32_menu_32_item: '/p/edit-menu-item',

--- a/src/app/project-administration/project-administration.module.ts
+++ b/src/app/project-administration/project-administration.module.ts
@@ -48,7 +48,9 @@ const routes: Routes = [
   },
 ];
 
-export const menuItems: MenuItem[] = [
+export const menuItems: MenuItem[] = [];
+
+/*[
   {
     label: 'Project administration',
     items: [
@@ -74,7 +76,7 @@ export const menuItems: MenuItem[] = [
       },
     ],
   },
-];
+];*/
 
 const INTERFACE_ROUTE_MAP: InterfaceRouteMap = {
   Active_32_projects: '/p/active-projects',

--- a/src/app/project-administration/project-administration.module.ts
+++ b/src/app/project-administration/project-administration.module.ts
@@ -47,7 +47,7 @@ const routes: Routes = [
   },
 ];
 
-export const INTERFACE_ROUTE_MAP: InterfaceRouteMap = {
+const INTERFACE_ROUTE_MAP: InterfaceRouteMap = {
   Active_32_projects: '/p/active-projects',
   Edit_32_interface: '/p/edit-interface',
   Edit_32_menu_32_item: '/p/edit-menu-item',

--- a/src/app/project-administration/project-administration.module.ts
+++ b/src/app/project-administration/project-administration.module.ts
@@ -8,7 +8,6 @@ import { PeopleComponent } from './people/people.component';
 import { BackendService } from './backend.service';
 import { RouterModule, Routes } from '@angular/router';
 import { AppLayoutComponent } from '../layout/app.layout.component';
-import { MenuItem } from 'primeng/api';
 import { ListAllInterfacesComponent } from './list-all-interfaces/list-all-interfaces.component';
 import { ProjectEditComponent } from './project-edit/project-edit.component';
 import { PersonComponent } from './person/person.component';
@@ -47,8 +46,6 @@ const routes: Routes = [
     ],
   },
 ];
-
-export const menuItems: MenuItem[] = [];
 
 export const INTERFACE_ROUTE_MAP: InterfaceRouteMap = {
   Active_32_projects: '/p/active-projects',

--- a/src/app/project-administration/project-administration.module.ts
+++ b/src/app/project-administration/project-administration.module.ts
@@ -50,34 +50,6 @@ const routes: Routes = [
 
 export const menuItems: MenuItem[] = [];
 
-/*[
-  {
-    label: 'Project administration',
-    items: [
-      {
-        label: 'Active projects',
-        icon: 'pi pi-fw pi-bars',
-        routerLink: ['/p/active-projects'],
-      },
-      {
-        label: 'Inactive projects',
-        icon: 'pi pi-fw pi-bars',
-        routerLink: ['/p/inactive-projects'],
-      },
-      {
-        label: 'People',
-        icon: 'pi pi-fw pi-bars',
-        routerLink: ['/p/people'],
-      },
-      {
-        label: 'List all interfaces',
-        icon: 'pi pi-fw pi-bars',
-        routerLink: ['/p/list-all-interfaces'],
-      },
-    ],
-  },
-];*/
-
 export const INTERFACE_ROUTE_MAP: InterfaceRouteMap = {
   Active_32_projects: '/p/active-projects',
   Edit_32_interface: '/p/edit-interface',

--- a/src/app/shared/box-components/BaseBoxComponent.class.ts
+++ b/src/app/shared/box-components/BaseBoxComponent.class.ts
@@ -5,7 +5,7 @@ import { ObjectBase } from '../objectBase.interface';
 @Component({
   template: '',
 })
-export abstract class BaseBoxComponent<TItem, I> {
+export abstract class BaseBoxComponent<TItem extends ObjectBase, I> {
   @Input() data!: TItem[];
   @Input() interfaceComponent!: AmpersandInterface<I>;
 
@@ -24,7 +24,7 @@ export abstract class BaseBoxComponent<TItem, I> {
     return this.crud[3] == 'D';
   }
 
-  public deleteItem(resource: ObjectBase): void {
+  public deleteItem(resource: TItem): void {
     this.interfaceComponent.delete(resource).subscribe((x) => {
       if (x.isCommitted) {
         this.data.forEach((item, index) => {

--- a/src/app/shared/box-components/box-form/box-form.component.ts
+++ b/src/app/shared/box-components/box-form/box-form.component.ts
@@ -1,4 +1,5 @@
 import { Component, ContentChild, Input, TemplateRef } from '@angular/core';
+import { ObjectBase } from '../../objectBase.interface';
 import { BaseBoxComponent } from '../BaseBoxComponent.class';
 import { BoxFormTemplateDirective } from './box-form-template.directive';
 
@@ -7,7 +8,7 @@ import { BoxFormTemplateDirective } from './box-form-template.directive';
   templateUrl: './box-form.component.html',
   styleUrls: ['./box-form.component.scss'],
 })
-export class BoxFormComponent<TItem extends object, I> extends BaseBoxComponent<TItem, I> {
+export class BoxFormComponent<TItem extends ObjectBase, I> extends BaseBoxComponent<TItem, I> {
   @ContentChild(BoxFormTemplateDirective, { read: TemplateRef })
   template?: TemplateRef<unknown>;
 }

--- a/src/app/shared/box-components/box-tab/box-tab.component.ts
+++ b/src/app/shared/box-components/box-tab/box-tab.component.ts
@@ -1,4 +1,5 @@
 import { Component, ContentChild, Input, TemplateRef } from '@angular/core';
+import { ObjectBase } from '../../objectBase.interface';
 import { BaseBoxComponent } from '../BaseBoxComponent.class';
 
 @Component({
@@ -6,7 +7,7 @@ import { BaseBoxComponent } from '../BaseBoxComponent.class';
   templateUrl: './box-tab.component.html',
   styleUrls: ['./box-tab.component.scss'],
 })
-export class BoxTabComponent<TItem extends object, I> extends BaseBoxComponent<TItem, I> {
+export class BoxTabComponent<TItem extends ObjectBase, I> extends BaseBoxComponent<TItem, I> {
   @Input() tabHeaders: string[] = [];
   @ContentChild('tabContent') tabContent!: TemplateRef<any>;
 

--- a/src/app/shared/box-components/box-table/box-table.component.ts
+++ b/src/app/shared/box-components/box-table/box-table.component.ts
@@ -1,4 +1,5 @@
 import { Component, ContentChild, Input, TemplateRef } from '@angular/core';
+import { ObjectBase } from '../../objectBase.interface';
 import { BaseBoxComponent } from '../BaseBoxComponent.class';
 import { BoxTableHeaderTemplateDirective } from './box-table-header-template.directive';
 import { BoxTableRowTemplateDirective } from './box-table-row-template.directive';
@@ -8,7 +9,7 @@ import { BoxTableRowTemplateDirective } from './box-table-row-template.directive
   templateUrl: './box-table.component.html',
   styleUrls: ['./box-table.component.css'],
 })
-export class BoxTableComponent<TItem extends object, I> extends BaseBoxComponent<TItem, I> {
+export class BoxTableComponent<TItem extends ObjectBase, I> extends BaseBoxComponent<TItem, I> {
   @ContentChild(BoxTableHeaderTemplateDirective, { read: TemplateRef })
   headers?: TemplateRef<unknown>;
   @ContentChild(BoxTableRowTemplateDirective, { read: TemplateRef })

--- a/src/app/shared/interfacing/navbar.interface.ts
+++ b/src/app/shared/interfacing/navbar.interface.ts
@@ -29,7 +29,7 @@ interface Ext {
   function: Object;
 }
 
-interface Navs {
+export interface Navs {
   id: string;
   ifc: string | null;
   label: string;


### PR DESCRIPTION
This branch adds the dynamic nav menu. With dynamic, we mean that the menu items are fetched from the backend, instead of being hardcoded. 

Some design choices / behaviour:
 - While submenus are currently not showing (because of the given data), they are supported. Main 'parent' items don't show their submenus in a dropdown, but if one of those submenus has submenus, a dropdown arrow will appear.
 - When an item with a parent is read, but the parent does not exist yet, it is put in a temporary `childItems()` array. Once the rest of the items have been added, the 'parked' child items are added. 

(Potentially) unwanted behaviour:
 - GET navbar is called twice. 
 - This happens each time a new page is loaded (i.e. it is not cached)
 - If any MenuItem has a parent assigned that does not exist, the while loop will not terminate.