### PR TITLE
Feat/toast service

### DIFF
--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -61,7 +61,14 @@ export const menuItems: MenuItem[] = [
 ];
 
 @NgModule({
-  declarations: [InstallerComponent, UtilsComponent, PopulationComponent, ReportComponent, ImportComponent, RolesComponent],
+  declarations: [
+    InstallerComponent,
+    UtilsComponent,
+    PopulationComponent,
+    ReportComponent,
+    ImportComponent,
+    RolesComponent,
+  ],
   imports: [CommonModule, RouterModule.forChild(routes), CardModule, ButtonModule, NgxDropzoneModule, MenuModule],
   providers: [
     { provide: InstallerService, useClass: InstallerService },

--- a/src/app/admin/population/import/import.component.ts
+++ b/src/app/admin/population/import/import.component.ts
@@ -1,5 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component } from '@angular/core';
+import { MessageService } from 'primeng/api';
 import { ButtonState } from 'src/app/shared/helper/button-state';
 import { PopulationService } from '../population.service';
 
@@ -15,7 +16,7 @@ export class ImportComponent {
   buttonState1: ButtonState = new ButtonState();
   files: File[] = [];
 
-  constructor(private populationService: PopulationService) {}
+  constructor(private populationService: PopulationService, private messageService: MessageService) {}
 
   /**
    * Set the buttonState to its initial value
@@ -45,16 +46,20 @@ export class ImportComponent {
       // upload one file
       this.populationService.importPopulation(this.files.pop()).subscribe({
         error: (err: HttpErrorResponse) => {
-          // Change button colour (temporary)
-          this.buttonState1.error = true;
-          this.buttonState1.success = false;
-
           // Invoke notification
-          console.log('Error uploading file:');
-          console.log(err.message);
-          // TODO: Replace with Notification component
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Error while uploading file',
+            detail: err.message,
+            life: 10000,
+          });
         },
-        complete: () => (this.buttonState1.success = true),
+        complete: () =>
+          this.messageService.add({
+            severity: 'success',
+            summary: 'File upload complete',
+            life: 5000,
+          }),
         next: () => {},
       });
     }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet> <p-toast></p-toast>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,12 +1,13 @@
 import { OnInit } from '@angular/core';
 import { Component } from '@angular/core';
-import { PrimeNGConfig } from 'primeng/api';
+import { MessageService, PrimeNGConfig } from 'primeng/api';
 import { LayoutService } from './layout/service/app.layout.service';
 
 @Component({
   selector: 'app-root',
-  template: '<router-outlet></router-outlet>',
-  styleUrls: ['./app.component.scss'],
+  templateUrl: './app.component.html',
+  styleUrls: ['app.component.scss'],
+  providers: [MessageService],
 })
 export class AppComponent implements OnInit {
   title = 'prototype-frontend';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { AppLayoutModule } from './layout/app.layout.module';
 import { ProjectAdministrationModule } from './project-administration/project-administration.module';
 import { SharedModule } from './shared/shared.module';
 import { ToolsModule } from './tools/tools.module';
+import { ToastModule } from 'primeng/toast';
 
 @NgModule({
   declarations: [AppComponent],
@@ -23,6 +24,7 @@ import { ToolsModule } from './tools/tools.module';
     ToolsModule,
     AdminModule,
     AppRoutingModule,
+    ToastModule,
   ],
   providers: [httpInterceptorProviders],
   bootstrap: [AppComponent],

--- a/src/app/project-administration/active-projects/active-projects.component.ts
+++ b/src/app/project-administration/active-projects/active-projects.component.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
+import { MessageService } from 'primeng/api';
 import { Observable } from 'rxjs';
 import { AmpersandInterface } from 'src/app/shared/interfacing/ampersand-interface.class';
 import { BackendService } from '../backend.service';
@@ -11,8 +12,8 @@ import { ActiveProjectsInterface } from './active-projects.interface';
   styleUrls: ['./active-projects.component.css'],
 })
 export class ActiveProjectsComponent extends AmpersandInterface<ActiveProjectsInterface> implements OnInit {
-  constructor(protected service: BackendService, http: HttpClient) {
-    super(http);
+  constructor(protected service: BackendService, http: HttpClient, messageService: MessageService) {
+    super(http, messageService);
   }
 
   ngOnInit(): void {

--- a/src/app/project-administration/inactive-projects/inactive-projects.component.ts
+++ b/src/app/project-administration/inactive-projects/inactive-projects.component.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
+import { MessageService } from 'primeng/api';
 import { AmpersandInterface } from 'src/app/shared/interfacing/ampersand-interface.class';
 import { BackendService } from '../backend.service';
 import { InactiveProjectsInterface } from './inactive-projects.interface';
@@ -11,8 +11,8 @@ import { InactiveProjectsInterface } from './inactive-projects.interface';
   styleUrls: ['./inactive-projects.component.css'],
 })
 export class InactiveProjectsComponent extends AmpersandInterface<InactiveProjectsInterface> implements OnInit {
-  constructor(protected service: BackendService, http: HttpClient) {
-    super(http);
+  constructor(protected service: BackendService, http: HttpClient, messageService: MessageService) {
+    super(http, messageService);
   }
 
   ngOnInit(): void {

--- a/src/app/project-administration/list-all-interfaces/list-all-interfaces.component.ts
+++ b/src/app/project-administration/list-all-interfaces/list-all-interfaces.component.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
+import { MessageService } from 'primeng/api';
 import { Observable } from 'rxjs';
 import { AmpersandInterface } from 'src/app/shared/interfacing/ampersand-interface.class';
 import { BackendService } from '../backend.service';
@@ -11,8 +12,8 @@ import { ListAllInterfacesInterface } from './list-all-interfaces.interface';
   styleUrls: ['./list-all-interfaces.component.css'],
 })
 export class ListAllInterfacesComponent extends AmpersandInterface<ListAllInterfacesInterface> implements OnInit {
-  constructor(protected service: BackendService, http: HttpClient) {
-    super(http);
+  constructor(protected service: BackendService, http: HttpClient, messageService: MessageService) {
+    super(http, messageService);
   }
 
   ngOnInit(): void {

--- a/src/app/project-administration/people/people.component.ts
+++ b/src/app/project-administration/people/people.component.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { MessageService } from 'primeng/api';
 import { Observable } from 'rxjs';
 import { AmpersandInterface } from 'src/app/shared/interfacing/ampersand-interface.class';
 import { BackendService } from '../backend.service';
@@ -12,8 +13,13 @@ import { PeopleInterface } from './people.interface';
   styleUrls: ['./people.component.scss'],
 })
 export class PeopleComponent extends AmpersandInterface<PeopleInterface> implements OnInit {
-  constructor(protected service: BackendService, private router: Router, http: HttpClient) {
-    super(http);
+  constructor(
+    protected service: BackendService,
+    private router: Router,
+    http: HttpClient,
+    messageService: MessageService,
+  ) {
+    super(http, messageService);
   }
 
   ngOnInit(): void {

--- a/src/app/project-administration/person/person.component.ts
+++ b/src/app/project-administration/person/person.component.ts
@@ -8,6 +8,7 @@ import { PatchResponse } from 'src/app/shared/interfacing/patch-response.interfa
 import { BackendService } from '../backend.service';
 import { PersonInterface } from './person.interface';
 import { DeleteResponse } from 'src/app/shared/interfacing/delete-response.interface';
+import { MessageService } from 'primeng/api';
 
 @Component({
   selector: 'app-person',
@@ -17,8 +18,13 @@ import { DeleteResponse } from 'src/app/shared/interfacing/delete-response.inter
 export class PersonComponent extends AmpersandInterface<PersonInterface> implements OnInit {
   private personId!: string;
 
-  constructor(private route: ActivatedRoute, protected service: BackendService, http: HttpClient) {
-    super(http);
+  constructor(
+    private route: ActivatedRoute,
+    protected service: BackendService,
+    http: HttpClient,
+    messageService: MessageService,
+  ) {
+    super(http, messageService);
   }
 
   ngOnInit(): void {

--- a/src/app/project-administration/project-edit/project-edit.component.ts
+++ b/src/app/project-administration/project-edit/project-edit.component.ts
@@ -5,6 +5,7 @@ import { AmpersandInterface } from 'src/app/shared/interfacing/ampersand-interfa
 import { Observable, switchMap, tap } from 'rxjs';
 import { BackendService } from '../backend.service';
 import { ProjectEditInterface } from './project-edit.interface';
+import { MessageService } from 'primeng/api';
 
 @Component({
   selector: 'app-project-edit',
@@ -14,8 +15,13 @@ import { ProjectEditInterface } from './project-edit.interface';
 export class ProjectEditComponent extends AmpersandInterface<ProjectEditInterface> implements OnInit {
   public projectId!: string;
 
-  constructor(private route: ActivatedRoute, protected service: BackendService, http: HttpClient) {
-    super(http);
+  constructor(
+    private route: ActivatedRoute,
+    protected service: BackendService,
+    http: HttpClient,
+    messageService: MessageService,
+  ) {
+    super(http, messageService);
   }
 
   ngOnInit(): void {

--- a/src/app/project-administration/project/project.component.ts
+++ b/src/app/project-administration/project/project.component.ts
@@ -6,6 +6,7 @@ import { ProjectInterface } from './project.interface';
 import { Router, Navigation } from '@angular/router';
 import { AmpersandInterface } from 'src/app/shared/interfacing/ampersand-interface.class';
 import { HttpClient } from '@angular/common/http';
+import { MessageService } from 'primeng/api';
 
 @Component({
   selector: 'app-project',
@@ -20,8 +21,9 @@ export class ProjectComponent extends AmpersandInterface<ProjectInterface> imple
     protected service: BackendService,
     private router: Router,
     http: HttpClient,
+    messageService: MessageService,
   ) {
-    super(http);
+    super(http, messageService);
   }
 
   ngOnInit(): void {

--- a/src/app/shared/atomic-components/BaseAtomicComponent.class.ts
+++ b/src/app/shared/atomic-components/BaseAtomicComponent.class.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
+import { Message, MessageService } from 'primeng/api';
 import { AmpersandInterface } from '../interfacing/ampersand-interface.class';
 import { ObjectBase } from '../objectBase.interface';
 @Component({
@@ -39,6 +40,8 @@ export abstract class BaseAtomicComponent<T, I> implements OnInit {
   }
 
   @Input() crud: string = 'cRud';
+
+  constructor(protected messageService: MessageService) {}
 
   public canCreate(): boolean {
     return this.crud[0] == 'C';
@@ -106,5 +109,9 @@ export abstract class BaseAtomicComponent<T, I> implements OnInit {
 
   public isNewItemInputRequired() {
     return this.isTot && this.data.length === 0;
+  }
+
+  public addMessage(message: Message) {
+    this.messageService.add(message);
   }
 }

--- a/src/app/shared/atomic-components/atomic-alphanumeric/atomic-alphanumeric.component.ts
+++ b/src/app/shared/atomic-components/atomic-alphanumeric/atomic-alphanumeric.component.ts
@@ -1,5 +1,7 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
+import { MessageService } from 'primeng/api';
 import { map } from 'rxjs';
 import { BaseAtomicComponent } from '../BaseAtomicComponent.class';
 
@@ -36,7 +38,21 @@ export class AtomicAlphanumericComponent<I> extends BaseAtomicComponent<string, 
                 value: x,
               },
             ])
-            .subscribe(),
+            .subscribe({
+              error: (err: HttpErrorResponse) => {
+                super.addMessage({
+                  severity: 'error',
+                  summary: err.status.toString(),
+                  detail: err.message,
+                });
+              },
+              complete: () => {
+                super.addMessage({
+                  severity: 'success',
+                  summary: 'Successfully updated form.',
+                });
+              },
+            }),
         );
     }
   }

--- a/src/app/shared/atomic-components/atomic-boolean/atomic-boolean.component.ts
+++ b/src/app/shared/atomic-components/atomic-boolean/atomic-boolean.component.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { BaseAtomicComponent } from '../BaseAtomicComponent.class';
@@ -72,7 +73,14 @@ export class AtomicBooleanComponent<I> extends BaseAtomicComponent<boolean, I> i
               value: x,
             },
           ])
-          .subscribe(),
+          .subscribe({
+            error: (err: HttpErrorResponse) => {
+              super.addMessage({ severity: 'error', summary: 'Error updating value.', detail: err.message });
+            },
+            complete: () => {
+              super.addMessage({ severity: 'success', summary: 'Value updated.' });
+            },
+          }),
       );
     }
   }

--- a/src/app/shared/atomic-components/atomic-object/atomic-object.component.ts
+++ b/src/app/shared/atomic-components/atomic-object/atomic-object.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, Input, OnInit } from '@angular/core';
-import { MenuItem } from 'primeng/api';
+import { MenuItem, MessageService } from 'primeng/api';
 import { BaseAtomicComponent } from '../BaseAtomicComponent.class';
 import { Router } from '@angular/router';
 import { InterfaceRefObject, ObjectBase } from '../../objectBase.interface';
@@ -23,8 +23,9 @@ export class AtomicObjectComponent<I> extends BaseAtomicComponent<ObjectBase, I>
     private router: Router,
     private http: HttpClient, // required to make property 'itemsMethod' work
     @Inject(INTERFACE_ROUTE_MAPPING_TOKEN) private interfaceRouteMap: InterfaceRouteMap,
+    protected override messageService: MessageService,
   ) {
-    super();
+    super(messageService);
   }
 
   override ngOnInit(): void {

--- a/src/app/shared/interfacing/ampersand-interface.class.ts
+++ b/src/app/shared/interfacing/ampersand-interface.class.ts
@@ -4,18 +4,30 @@ import { ObjectBase } from '../objectBase.interface';
 import { Patch, PatchValue } from './patch.interface';
 import { PatchResponse } from './patch-response.interface';
 import { DeleteResponse } from './delete-response.interface';
+import { MessageService } from 'primeng/api';
+import { Invariant } from './notifications.interface';
 
 export class AmpersandInterface<T> {
   public data$!: Observable<T>;
 
-  constructor(protected http: HttpClient) {}
+  constructor(protected http: HttpClient, private messageService: MessageService) {}
 
   public patch(resource: ObjectBase, patches: Array<Patch | PatchValue>): Observable<PatchResponse<T>> {
     return this.http.patch<PatchResponse<T>>(resource._path_, patches).pipe(
       tap((x) => {
         // TODO: show warning message of x.notifications.invariants
         if (!x.invariantRulesHold) {
-          console.log('Invariants do not hold');
+          //console.log('Invariants do not hold');
+          let invariants: string = '';
+          x.notifications.invariants.forEach((inv) => {
+            invariants += inv.ruleMessage;
+            invariants += '\n';
+          });
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Invariants do not hold',
+            detail: invariants,
+          });
         }
 
         // console.log('Current resource', resource);

--- a/src/app/shared/interfacing/notifications.interface.ts
+++ b/src/app/shared/interfacing/notifications.interface.ts
@@ -3,6 +3,11 @@ export interface Notifications {
   warnings: Array<unknown>;
   infos: Array<unknown>;
   successes: Array<unknown>;
-  invariants: Array<unknown>;
+  invariants: Array<Invariant>;
   signals: Array<unknown>;
+}
+
+export interface Invariant {
+  ruleMessage: string;
+  tuples: Array<string>;
 }

--- a/src/app/tools/tool-gallery/tool-gallery.component.ts
+++ b/src/app/tools/tool-gallery/tool-gallery.component.ts
@@ -8,6 +8,7 @@ import { testdata } from '../testdata';
 import { applyPatch } from 'fast-json-patch';
 import { HttpClient } from '@angular/common/http';
 import { ObjectBase } from 'src/app/shared/objectBase.interface';
+import { MessageService } from 'primeng/api';
 
 @Component({
   selector: 'app-tool-gallery',
@@ -17,8 +18,8 @@ import { ObjectBase } from 'src/app/shared/objectBase.interface';
 export class ToolGalleryComponent extends AmpersandInterface<TestDataInterface> {
   data: TestDataInterface = JSON.parse(JSON.stringify(testdata[0]));
 
-  constructor(http: HttpClient) {
-    super(http);
+  constructor(http: HttpClient, messageService: MessageService) {
+    super(http, messageService);
   }
 
   override patch<TestDataInterface>(


### PR DESCRIPTION
This PR adds a `MessageService`, which allows components to send notifications to the user, using [toasts](https://www.primefaces.org/primeng-v13/toast). 

For a guide on how to add this support to a component, click [here](https://github.com/AmpersandTarski/prototype-frontend/issues/166#issuecomment-1458302285).

